### PR TITLE
added collection and update form support

### DIFF
--- a/lib/client/autoform-tags.coffee
+++ b/lib/client/autoform-tags.coffee
@@ -5,6 +5,9 @@ AutoForm.addInputType 'tags',
 	valueConverters:
 		stringArray: (value) ->
 			value.split ','
+	contextAdjust: (context) ->
+		_.extend context.atts, {itemscontextValue: context.value}
+		context
 
 Template.autoformTags.rendered = ->
 	self = @$ '.js-input'
@@ -14,6 +17,17 @@ Template.autoformTags.rendered = ->
 
 	self.tagsinput @data.atts
 
+	if @data.atts.itemscontextValue
+		if @data.atts.collection
+			collection = if (@data.atts.collection is 'users') then Meteor.users else window[@data.atts.collection]
+			relObjs = collection.find({_id: {$in: @data.atts.itemscontextValue}}).fetch()
+			_.each relObjs, (doc) ->
+				self.tagsinput 'add', doc
+		else
+			_.each @itemscontextValue, (val) ->
+				self.tagsinput 'add', val
+
 Template.autoformTags.helpers
 	schemaKey: ->
 		@atts['data-schema-key']
+

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'yogiben:autoform-tags',
   summary: 'Tags input for aldeed:autoform',
-  version: '0.1.0',
+  version: '0.1.1',
   git: 'https://github.com/yogiben/meteor-autoform-tags'
 });
 


### PR DESCRIPTION
Hi @yogiben and @mpowaga I'm not totally sure if my solution is applicable for all use cases of the bootstrap tagsinput but it works well for me.

To use the Meteor.users collection, I didn't find a quick and elegant solution so I settled for this hacky implementation of checking if the collection name is 'users'.

Let me know if you see any sort of problem with this PR, it's my first one...
